### PR TITLE
DOC show how to extend estimator tags if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,15 @@ In case you want to extend the tags, you can inherit from the available tags:
 from sklearn_compat.utils._tags import Tags, InputTags
 
 class MyInputTags(InputTags):
-    dataframe: bool = True
+    dataframe: bool = False
 
 class MyEstimator(BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        tags.input_tags = MyInputTags()
+        tags.input_tags = MyInputTags(
+            category=True,
+            dataframe=True,
+        )
         return tags
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ tags = get_tags(MyEstimator())
 
 Which uses `sklearn.utils.get_tags` under the hood from scikit-learn 1.6+.
 
-In case, that you want to extend the tags a given tags, you can inherit from the
-available tags:
+In case you want to extend the tags, you can inherit from the available tags:
 
 ```py
 from sklearn_compat.utils._tags import Tags, InputTags

--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ tags = get_tags(MyEstimator())
 
 Which uses `sklearn.utils.get_tags` under the hood from scikit-learn 1.6+.
 
+In case, that you want to extend the tags a given tags, you can inherit from the
+available tags:
+
+```py
+from sklearn_compat.utils._tags import Tags, InputTags
+
+class MyInputTags(InputTags):
+    dataframe: bool = True
+
+class MyEstimator(BaseEstimator):
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags = MyInputTags()
+        return tags
+```
+
+
 #### `check_estimator` and `parametrize_with_checks` functions
 
 The new tags don't include a `_xfail_checks` tags, and instead, the tests which are

--- a/README.md
+++ b/README.md
@@ -141,8 +141,16 @@ class MyEstimator(BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags = MyInputTags(
+            one_d_array=tags.input_tags.one_d_array,
+            two_d_array=tags.input_tags.two_d_array,
+            sparse=tags.input_tags.sparse,
             category=True,
             dataframe=True,
+            string=tags.input_tags.string,
+            dict=tags.input_tags.dict,
+            positive_only=tags.input_tags.positive_only,
+            allow_nan=tags.input_tags.allow_nan,
+            pairwise=tags.input_tags.pairwise,
         )
         return tags
 ```


### PR DESCRIPTION
A small change in the documentation to show that you can extend the tags with inheritance.