### PR TITLE
MAINT support the transition from force_all_finite to ensure_all_finite in check_array

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ parameter. You need to modify the call to the function to use the new parameter.
 the change is the same as for `validate_data` and will look like this:
 
 ``` py
-from sklearn_compat.utils.validation import check_array
+from sklearn.utils.validation import check_array
 
 check_array(X, force_all_finite=True)
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ check_array(X, force_all_finite=True)
 to:
 
 ``` py
+from sklearn_compat.utils.validation import check_array
+
 check_array(X, ensure_all_finite=True)
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ class MyEstimator(BaseEstimator):
         return self
 ```
 
+#### `check_array` function
+
+The parameter `force_all_finite` has been deprecated in favor of the `ensure_all_finite`
+parameter. You need to modify the call to the function to use the new parameter. So,
+the change is the same as for `validate_data` and will look like this:
+
+``` py
+from sklearn_compat.utils.validation import check_array
+
+check_array(X, force_all_finite=True)
+```
+
+to:
+
+``` py
+check_array(X, ensure_all_finite=True)
+```
+
 #### `_check_n_features` and `_check_feature_names` functions
 
 Similarly to `validate_data`, these two functions have been moved to

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -12,6 +12,7 @@ Version: 0.1.1
 from __future__ import annotations
 
 import functools
+import inspect
 import platform
 import sys
 from dataclasses import dataclass, field
@@ -388,111 +389,8 @@ if sklearn_version < parse_version("1.6"):
     ):
         """Input validation on an array, list, sparse matrix or similar.
 
-        By default, the input is checked to be a non-empty 2D array containing
-        only finite values. If the dtype of the array is object, attempt
-        converting to float, raising on failure.
-
-        Parameters
-        ----------
-        array : object
-            Input object to check / convert.
-
-        accept_sparse : str, bool or list/tuple of str, default=False
-            String[s] representing allowed sparse matrix formats, such as 'csc',
-            'csr', etc. If the input is sparse but not in the allowed format,
-            it will be converted to the first listed format. True allows the input
-            to be any format. False means that a sparse matrix input will
-            raise an error.
-
-        accept_large_sparse : bool, default=True
-            If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
-            accept_sparse, accept_large_sparse=False will cause it to be accepted
-            only if its indices are stored with a 32-bit dtype.
-
-            .. versionadded:: 0.20
-
-        dtype : 'numeric', type, list of type or None, default='numeric'
-            Data type of result. If None, the dtype of the input is preserved.
-            If "numeric", dtype is preserved unless array.dtype is object.
-            If dtype is a list of types, conversion on the first type is only
-            performed if the dtype of the input is not in the list.
-
-        order : {'F', 'C'} or None, default=None
-            Whether an array will be forced to be fortran or c-style.
-            When order is None (default), then if copy=False, nothing is ensured
-            about the memory layout of the output array; otherwise (copy=True)
-            the memory layout of the returned array is kept as close as possible
-            to the original array.
-
-        copy : bool, default=False
-            Whether a forced copy will be triggered. If copy=False, a copy might
-            be triggered by a conversion.
-
-        force_writeable : bool, default=False
-            Whether to force the output array to be writeable. If True, the returned array
-            is guaranteed to be writeable, which may require a copy. Otherwise the
-            writeability of the input array is preserved.
-
-            .. versionadded:: 1.6
-
-        ensure_all_finite : bool or 'allow-nan', default=True
-            Whether to raise an error on np.inf, np.nan, pd.NA in array. The
-            possibilities are:
-
-            - True: Force all values of array to be finite.
-            - False: accepts np.inf, np.nan, pd.NA in array.
-            - 'allow-nan': accepts only np.nan and pd.NA values in array. Values
-            cannot be infinite.
-
-            .. versionadded:: 1.6
-            `force_all_finite` was renamed to `ensure_all_finite`.
-
-        ensure_non_negative : bool, default=False
-            Make sure the array has only non-negative values. If True, an array that
-            contains negative values will raise a ValueError.
-
-            .. versionadded:: 1.6
-
-        ensure_2d : bool, default=True
-            Whether to raise a value error if array is not 2D.
-
-        allow_nd : bool, default=False
-            Whether to allow array.ndim > 2.
-
-        ensure_min_samples : int, default=1
-            Make sure that the array has a minimum number of samples in its first
-            axis (rows for a 2D array). Setting to 0 disables this check.
-
-        ensure_min_features : int, default=1
-            Make sure that the 2D array has some minimum number of features
-            (columns). The default value of 1 rejects empty datasets.
-            This check is only enforced when the input data has effectively 2
-            dimensions or is originally 1D and ``ensure_2d`` is True. Setting to 0
-            disables this check.
-
-        estimator : str or estimator instance, default=None
-            If passed, include the name of the estimator in warning messages.
-
-        input_name : str, default=""
-            The data name used to construct the error message. In particular
-            if `input_name` is "X" and the data has NaN values and
-            allow_nan is False, the error message will link to the imputer
-            documentation.
-
-            .. versionadded:: 1.1.0
-
-        Returns
-        -------
-        array_converted : object
-            The converted and validated array.
-
-        Examples
-        --------
-        >>> from sklearn.utils.validation import check_array
-        >>> X = [[1, 2, 3], [4, 5, 6]]
-        >>> X_checked = check_array(X)
-        >>> X_checked
-        array([[1, 2, 3], [4, 5, 6]])
+        Check the original documentation for more details:
+        https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_array.html
         """
         from sklearn.utils.validation import check_array as _check_array
 
@@ -501,6 +399,11 @@ if sklearn_version < parse_version("1.6"):
         else:
             force_all_finite = True
 
+        check_array_params = inspect.signature(_check_array).parameters
+        kwargs = {}
+        if "force_writeable" in check_array_params:
+            kwargs["force_writeable"] = force_writeable
+
         return _check_array(
             array,
             accept_sparse=accept_sparse,
@@ -508,7 +411,6 @@ if sklearn_version < parse_version("1.6"):
             dtype=dtype,
             order=order,
             copy=copy,
-            force_writeable=force_writeable,
             force_all_finite=force_all_finite,
             ensure_non_negative=ensure_non_negative,
             ensure_2d=ensure_2d,
@@ -517,6 +419,7 @@ if sklearn_version < parse_version("1.6"):
             ensure_min_features=ensure_min_features,
             estimator=estimator,
             input_name=input_name,
+            **kwargs,
         )
 
     # tags infrastructure

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -386,6 +386,114 @@ if sklearn_version < parse_version("1.6"):
         estimator=None,
         input_name="",
     ):
+        """Input validation on an array, list, sparse matrix or similar.
+
+        By default, the input is checked to be a non-empty 2D array containing
+        only finite values. If the dtype of the array is object, attempt
+        converting to float, raising on failure.
+
+        Parameters
+        ----------
+        array : object
+            Input object to check / convert.
+
+        accept_sparse : str, bool or list/tuple of str, default=False
+            String[s] representing allowed sparse matrix formats, such as 'csc',
+            'csr', etc. If the input is sparse but not in the allowed format,
+            it will be converted to the first listed format. True allows the input
+            to be any format. False means that a sparse matrix input will
+            raise an error.
+
+        accept_large_sparse : bool, default=True
+            If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
+            accept_sparse, accept_large_sparse=False will cause it to be accepted
+            only if its indices are stored with a 32-bit dtype.
+
+            .. versionadded:: 0.20
+
+        dtype : 'numeric', type, list of type or None, default='numeric'
+            Data type of result. If None, the dtype of the input is preserved.
+            If "numeric", dtype is preserved unless array.dtype is object.
+            If dtype is a list of types, conversion on the first type is only
+            performed if the dtype of the input is not in the list.
+
+        order : {'F', 'C'} or None, default=None
+            Whether an array will be forced to be fortran or c-style.
+            When order is None (default), then if copy=False, nothing is ensured
+            about the memory layout of the output array; otherwise (copy=True)
+            the memory layout of the returned array is kept as close as possible
+            to the original array.
+
+        copy : bool, default=False
+            Whether a forced copy will be triggered. If copy=False, a copy might
+            be triggered by a conversion.
+
+        force_writeable : bool, default=False
+            Whether to force the output array to be writeable. If True, the returned array
+            is guaranteed to be writeable, which may require a copy. Otherwise the
+            writeability of the input array is preserved.
+
+            .. versionadded:: 1.6
+
+        ensure_all_finite : bool or 'allow-nan', default=True
+            Whether to raise an error on np.inf, np.nan, pd.NA in array. The
+            possibilities are:
+
+            - True: Force all values of array to be finite.
+            - False: accepts np.inf, np.nan, pd.NA in array.
+            - 'allow-nan': accepts only np.nan and pd.NA values in array. Values
+            cannot be infinite.
+
+            .. versionadded:: 1.6
+            `force_all_finite` was renamed to `ensure_all_finite`.
+
+        ensure_non_negative : bool, default=False
+            Make sure the array has only non-negative values. If True, an array that
+            contains negative values will raise a ValueError.
+
+            .. versionadded:: 1.6
+
+        ensure_2d : bool, default=True
+            Whether to raise a value error if array is not 2D.
+
+        allow_nd : bool, default=False
+            Whether to allow array.ndim > 2.
+
+        ensure_min_samples : int, default=1
+            Make sure that the array has a minimum number of samples in its first
+            axis (rows for a 2D array). Setting to 0 disables this check.
+
+        ensure_min_features : int, default=1
+            Make sure that the 2D array has some minimum number of features
+            (columns). The default value of 1 rejects empty datasets.
+            This check is only enforced when the input data has effectively 2
+            dimensions or is originally 1D and ``ensure_2d`` is True. Setting to 0
+            disables this check.
+
+        estimator : str or estimator instance, default=None
+            If passed, include the name of the estimator in warning messages.
+
+        input_name : str, default=""
+            The data name used to construct the error message. In particular
+            if `input_name` is "X" and the data has NaN values and
+            allow_nan is False, the error message will link to the imputer
+            documentation.
+
+            .. versionadded:: 1.1.0
+
+        Returns
+        -------
+        array_converted : object
+            The converted and validated array.
+
+        Examples
+        --------
+        >>> from sklearn.utils.validation import check_array
+        >>> X = [[1, 2, 3], [4, 5, 6]]
+        >>> X_checked = check_array(X)
+        >>> X_checked
+        array([[1, 2, 3], [4, 5, 6]])
+        """
         from sklearn.utils.validation import check_array as _check_array
 
         if ensure_all_finite is not None:

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -368,6 +368,49 @@ if sklearn_version < parse_version("1.6"):
     def _check_feature_names(estimator, X, *, reset):
         return estimator._check_feature_names(X, reset=reset)
 
+    def check_array(
+        array,
+        accept_sparse=False,
+        *,
+        accept_large_sparse=True,
+        dtype="numeric",
+        order=None,
+        copy=False,
+        force_writeable=False,
+        ensure_all_finite=None,
+        ensure_non_negative=False,
+        ensure_2d=True,
+        allow_nd=False,
+        ensure_min_samples=1,
+        ensure_min_features=1,
+        estimator=None,
+        input_name="",
+    ):
+        from sklearn.utils.validation import check_array as _check_array
+
+        if ensure_all_finite is not None:
+            force_all_finite = ensure_all_finite
+        else:
+            force_all_finite = True
+
+        return _check_array(
+            array,
+            accept_sparse=accept_sparse,
+            accept_large_sparse=accept_large_sparse,
+            dtype=dtype,
+            order=order,
+            copy=copy,
+            force_writeable=force_writeable,
+            force_all_finite=force_all_finite,
+            ensure_non_negative=ensure_non_negative,
+            ensure_2d=ensure_2d,
+            allow_nd=allow_nd,
+            ensure_min_samples=ensure_min_samples,
+            ensure_min_features=ensure_min_features,
+            estimator=estimator,
+            input_name=input_name,
+        )
+
     # tags infrastructure
     @dataclass(**_dataclass_args())
     class InputTags:
@@ -669,5 +712,6 @@ else:
     from sklearn.utils.validation import (
         _check_feature_names,  # noqa: F401
         _check_n_features,  # noqa: F401
+        check_array,  # noqa: F401
         validate_data,  # noqa: F401
     )

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -403,6 +403,8 @@ if sklearn_version < parse_version("1.6"):
         kwargs = {}
         if "force_writeable" in check_array_params:
             kwargs["force_writeable"] = force_writeable
+        if "ensure_non_negative" in check_array_params:
+            kwargs["ensure_non_negative"] = ensure_non_negative
 
         return _check_array(
             array,
@@ -412,7 +414,6 @@ if sklearn_version < parse_version("1.6"):
             order=order,
             copy=copy,
             force_all_finite=force_all_finite,
-            ensure_non_negative=ensure_non_negative,
             ensure_2d=ensure_2d,
             allow_nd=allow_nd,
             ensure_min_samples=ensure_min_samples,

--- a/src/sklearn_compat/utils/validation.py
+++ b/src/sklearn_compat/utils/validation.py
@@ -3,5 +3,6 @@ from sklearn_compat._sklearn_compat import (
     _check_n_features,  # noqa: F401
     _is_fitted,  # noqa: F401
     _to_object_array,  # noqa: F401
+    check_array,  # noqa: F401
     validate_data,  # noqa: F401
 )

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -7,8 +7,16 @@ from sklearn_compat.utils.validation import (
     _check_n_features,
     _is_fitted,
     _to_object_array,
+    check_array,
     validate_data,
 )
+
+
+def test_check_array_ensure_all_finite():
+    X = [[1, 2, 3, np.nan]]
+    with pytest.raises(ValueError, match="contains NaN"):
+        check_array(X, ensure_all_finite=True)
+    assert isinstance(check_array(X, ensure_all_finite=False), np.ndarray)
 
 
 @pytest.mark.parametrize("ensure_all_finite", [True, False])


### PR DESCRIPTION
Bring support for `ensure_all_finite` in `check_array`. In previous scikit-learn version, it is forwarded to `force_all_finite` that is now deprecated.