### PR TITLE
MAINT add function validate_params for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,17 +534,20 @@ class MetaEstimator(BaseEstimator):
         return self
 ```
 
-#### Upgrading to scikit-learn 1.3
+#### Upgrading to scikit-learn 1.2
 
 ### Parameter validation
 
 scikit-learn introduced a new way to validate parameters at `fit` time. The recommended
-way to support this feature in scikit-learn 1.3+ is to inherit from
+way to support this feature in scikit-learn 1.2+ is to inherit from
 `sklearn.base.BaseEstimator` and decorate the `fit` method using the decorator
-`sklearn.base._fit_context`.
+`sklearn.base._fit_context`. For functions, the decorator to use is
+`sklearn.utils._param_validation.validate_params`.
 
 We provide the function `sklearn_compat.base._fit_context` such that you can always
-decorate the `fit` method of your estimator.
+decorate the `fit` method of your estimator. Equivalently, you can use the function
+`sklearn_compat.utils._param_validation.validate_params` to validate the parameters
+of your function.
 
 ## Contributing
 

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -137,30 +137,7 @@ def _to_new_tags(old_tags, estimator=None):
 if sklearn_version < parse_version("1.3"):
     # parameter validation
     def _fit_context(*, prefer_skip_nested_validation):
-        """Decorator to run the fit methods of estimators within context managers.
-
-        With scikit-learn < 1.3, this decorator is no-op.
-
-        Parameters
-        ----------
-        prefer_skip_nested_validation : bool
-            If True, the validation of parameters of inner estimators or functions
-            called during fit will be skipped.
-
-            This is useful to avoid validating many times the parameters passed by the
-            user from the public facing API. It's also useful to avoid validating
-            parameters that we pass internally to inner functions that are guaranteed to
-            be valid by the test suite.
-
-            It should be set to True for most estimators, except for those that receive
-            non-validated objects as parameters, such as meta-estimators that are given
-            estimator objects.
-
-        Returns
-        -------
-        decorated_fit : method
-            The decorated fit method.
-        """
+        """Decorator to run the fit methods of estimators within context managers."""
 
         def decorator(fit_method):
             @functools.wraps(fit_method)
@@ -172,10 +149,17 @@ if sklearn_version < parse_version("1.3"):
 
         return decorator
 
+    def validate_params(parameter_constraints, *, prefer_skip_nested_validation):
+        """Validate the parameters of an estimator."""
+        from sklearn.utils._param_validation import validate_params
+
+        return validate_params(parameter_constraints)
+
 else:
     # parameter validation
 
     from sklearn.base import _fit_context  # noqa: F401
+    from sklearn.utils._param_validation import validate_params  # noqa: F401
 
 
 ########################################################################################

--- a/src/sklearn_compat/utils/_param_validation.py
+++ b/src/sklearn_compat/utils/_param_validation.py
@@ -1,0 +1,1 @@
+from sklearn_compat._sklearn_compat import validate_params  # noqa: F401

--- a/tests/utils/test_param_validation.py
+++ b/tests/utils/test_param_validation.py
@@ -1,0 +1,15 @@
+import pytest
+from sklearn.utils._param_validation import InvalidParameterError
+
+from sklearn_compat.utils._param_validation import validate_params
+
+
+def test_validate_params():
+    @validate_params({"x": [int, float]}, prefer_skip_nested_validation=True)
+    def func(x):
+        return x
+
+    func(1)
+    func(1.0)
+    with pytest.raises(InvalidParameterError):
+        func("a")


### PR DESCRIPTION
Add the function `validate_params` with the parameter `prefer_skip_nested_validation` to have a compatible signature.

For scikit-learn 1.2, this parameter is just ignored.