### PR TITLE
FEAT: add `check_X_y` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,24 +75,26 @@ class MyEstimator(BaseEstimator):
         return self
 ```
 
-#### `check_array` function
+#### `check_array` and `check_X_y` functions
 
 The parameter `force_all_finite` has been deprecated in favor of the `ensure_all_finite`
 parameter. You need to modify the call to the function to use the new parameter. So,
 the change is the same as for `validate_data` and will look like this:
 
 ``` py
-from sklearn.utils.validation import check_array
+from sklearn.utils.validation import check_array, check_X_y
 
 check_array(X, force_all_finite=True)
+check_X_y(X, y, force_all_finite=True)
 ```
 
 to:
 
 ``` py
-from sklearn_compat.utils.validation import check_array
+from sklearn_compat.utils.validation import check_array, check_X_y
 
 check_array(X, ensure_all_finite=True)
+check_X_y(X, y, ensure_all_finite=True)
 ```
 
 #### `_check_n_features` and `_check_feature_names` functions

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -481,9 +481,7 @@ if sklearn_version < parse_version("1.6"):
             force_all_finite = True
         else:
             force_all_finite = (
-                ensure_all_finite
-                if ensure_all_finite is not None
-                else force_all_finite
+                ensure_all_finite if ensure_all_finite is not None else force_all_finite
             )
 
         return _check_X_y(
@@ -504,9 +502,6 @@ if sklearn_version < parse_version("1.6"):
             y_numeric=y_numeric,
             estimator=estimator,
         )
-
-
-
 
     # tags infrastructure
     @dataclass(**_dataclass_args())

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -484,6 +484,13 @@ if sklearn_version < parse_version("1.6"):
                 ensure_all_finite if ensure_all_finite is not None else force_all_finite
             )
 
+        check_X_y_params = inspect.signature(_check_X_y).parameters
+        kwargs = (
+            {"force_writeable": force_writeable}
+            if "force_writeable" in check_X_y_params
+            else {}
+        )
+
         return _check_X_y(
             X,
             y,
@@ -492,7 +499,6 @@ if sklearn_version < parse_version("1.6"):
             dtype=dtype,
             order=order,
             copy=copy,
-            force_writeable=force_writeable,
             force_all_finite=force_all_finite,
             ensure_2d=ensure_2d,
             allow_nd=allow_nd,
@@ -501,6 +507,7 @@ if sklearn_version < parse_version("1.6"):
             ensure_min_features=ensure_min_features,
             y_numeric=y_numeric,
             estimator=estimator,
+            **kwargs,
         )
 
     # tags infrastructure

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -445,6 +445,69 @@ if sklearn_version < parse_version("1.6"):
             **kwargs,
         )
 
+    def check_X_y(
+        X,
+        y,
+        accept_sparse=False,
+        *,
+        accept_large_sparse=True,
+        dtype="numeric",
+        order=None,
+        copy=False,
+        force_writeable=False,
+        force_all_finite="deprecated",
+        ensure_all_finite=None,
+        ensure_2d=True,
+        allow_nd=False,
+        multi_output=False,
+        ensure_min_samples=1,
+        ensure_min_features=1,
+        y_numeric=False,
+        estimator=None,
+    ):
+        """Input validation for standard estimators.
+
+        Check the original documentation for more details:
+        https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_X_y.html
+        """
+        from sklearn.utils.validation import check_X_y as _check_X_y
+
+        if ensure_all_finite is not None and force_all_finite != "deprecated":
+            raise ValueError(
+                "'force_all_finite' and 'ensure_all_finite' cannot be used together. "
+                "Pass `ensure_all_finite` only."
+            )
+        elif ensure_all_finite is None and force_all_finite == "deprecated":
+            force_all_finite = True
+        else:
+            force_all_finite = (
+                ensure_all_finite
+                if ensure_all_finite is not None
+                else force_all_finite
+            )
+
+        return _check_X_y(
+            X,
+            y,
+            accept_sparse=accept_sparse,
+            accept_large_sparse=accept_large_sparse,
+            dtype=dtype,
+            order=order,
+            copy=copy,
+            force_writeable=force_writeable,
+            force_all_finite=force_all_finite,
+            ensure_2d=ensure_2d,
+            allow_nd=allow_nd,
+            multi_output=multi_output,
+            ensure_min_samples=ensure_min_samples,
+            ensure_min_features=ensure_min_features,
+            y_numeric=y_numeric,
+            estimator=estimator,
+        )
+
+
+
+
     # tags infrastructure
     @dataclass(**_dataclass_args())
     class InputTags:
@@ -747,5 +810,6 @@ else:
         _check_feature_names,  # noqa: F401
         _check_n_features,  # noqa: F401
         check_array,  # noqa: F401
+        check_X_y,  # noqa: F401
         validate_data,  # noqa: F401
     )

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -485,11 +485,9 @@ if sklearn_version < parse_version("1.6"):
             )
 
         check_X_y_params = inspect.signature(_check_X_y).parameters
-        kwargs = (
-            {"force_writeable": force_writeable}
-            if "force_writeable" in check_X_y_params
-            else {}
-        )
+        kwargs = {}
+        if "force_writeable" in check_array_params:
+            kwargs["force_writeable"] = force_writeable
 
         return _check_X_y(
             X,

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -455,7 +455,6 @@ if sklearn_version < parse_version("1.6"):
         order=None,
         copy=False,
         force_writeable=False,
-        force_all_finite="deprecated",
         ensure_all_finite=None,
         ensure_2d=True,
         allow_nd=False,
@@ -472,21 +471,14 @@ if sklearn_version < parse_version("1.6"):
         """
         from sklearn.utils.validation import check_X_y as _check_X_y
 
-        if ensure_all_finite is not None and force_all_finite != "deprecated":
-            raise ValueError(
-                "'force_all_finite' and 'ensure_all_finite' cannot be used together. "
-                "Pass `ensure_all_finite` only."
-            )
-        elif ensure_all_finite is None and force_all_finite == "deprecated":
-            force_all_finite = True
+        if ensure_all_finite is not None:
+            force_all_finite = ensure_all_finite
         else:
-            force_all_finite = (
-                ensure_all_finite if ensure_all_finite is not None else force_all_finite
-            )
+            force_all_finite = True
 
         check_X_y_params = inspect.signature(_check_X_y).parameters
         kwargs = {}
-        if "force_writeable" in check_array_params:
+        if "force_writeable" in check_X_y_params:
             kwargs["force_writeable"] = force_writeable
 
         return _check_X_y(

--- a/src/sklearn_compat/utils/validation.py
+++ b/src/sklearn_compat/utils/validation.py
@@ -4,5 +4,6 @@ from sklearn_compat._sklearn_compat import (
     _is_fitted,  # noqa: F401
     _to_object_array,  # noqa: F401
     check_array,  # noqa: F401
+    check_X_y,  # noqa: F401
     validate_data,  # noqa: F401
 )

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -20,12 +20,14 @@ def test_check_array_ensure_all_finite():
         check_array(X, ensure_all_finite=True)
     assert isinstance(check_array(X, ensure_all_finite=False), np.ndarray)
 
+
 def test_check_X_y_ensure_all_finite():
     X = [[1, 2, 3, np.nan]]
     y = [1, 0, 1, 0]
     with pytest.raises(ValueError, match="contains NaN"):
         check_X_y(X, ensure_all_finite=True)
     assert isinstance(check_X_y(X, ensure_all_finite=False), np.ndarray)
+
 
 @pytest.mark.parametrize("ensure_all_finite", [True, False])
 def test_validate_data(ensure_all_finite):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -9,6 +9,7 @@ from sklearn_compat.utils.validation import (
     _is_fitted,
     _to_object_array,
     check_array,
+    check_X_y,
     validate_data,
 )
 
@@ -19,6 +20,12 @@ def test_check_array_ensure_all_finite():
         check_array(X, ensure_all_finite=True)
     assert isinstance(check_array(X, ensure_all_finite=False), np.ndarray)
 
+def test_check_X_y_ensure_all_finite():
+    X = [[1, 2, 3, np.nan]]
+    y = [1, 0, 1, 0]
+    with pytest.raises(ValueError, match="contains NaN"):
+        check_X_y(X, ensure_all_finite=True)
+    assert isinstance(check_X_y(X, ensure_all_finite=False), np.ndarray)
 
 @pytest.mark.parametrize("ensure_all_finite", [True, False])
 def test_validate_data(ensure_all_finite):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -22,11 +22,11 @@ def test_check_array_ensure_all_finite():
 
 
 def test_check_X_y_ensure_all_finite():
-    X = [[1, 2, 3, np.nan]]
-    y = [1, 0, 1, 0]
+    X, y = [[1, 2, 3, np.nan]], [1]
     with pytest.raises(ValueError, match="contains NaN"):
-        check_X_y(X, ensure_all_finite=True)
-    assert isinstance(check_X_y(X, ensure_all_finite=False), np.ndarray)
+        check_X_y(X, y, ensure_all_finite=True)
+    X_, y_ = check_X_y(X, y, ensure_all_finite=False)
+    assert isinstance(X_, np.ndarray) and isinstance(y_, np.ndarray)
 
 
 @pytest.mark.parametrize("ensure_all_finite", [True, False])


### PR DESCRIPTION
# Description

Closes #24 by adding support for `check_X_y` in a similar fashion to how `check_array` is implemented