### PR TITLE
ENH add process_routing, _raise_for_params, and _is_pandas_df

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,12 +513,13 @@ check_pandas_support("sklearn_compat")
 
 #### `process_routing` and `_raise_for_params` functions
 
-The signature of the `process_routing` function changed in scikit-learn 1.4. You don't
-need to change the import but only the call to the function. Calling the function with
-the new signature will be compatible with the previous signature as well. So a code
-looking like this:
+The signature of the `process_routing` function changed in scikit-learn 1.4. You can
+import the function from `sklearn_compat.utils.metadata_routing`. The pattern will
+change from:
 
 ``` py
+from sklearn.utils.metadata_routing import process_routing
+
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", fit_params, sample_weight=sample_weight)
@@ -528,6 +529,8 @@ class MetaEstimator(BaseEstimator):
 becomes:
 
 ``` py
+from sklearn_compat.utils.metadata_routing import process_routing
+
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", sample_weight=sample_weight, **fit_params)

--- a/README.md
+++ b/README.md
@@ -511,14 +511,15 @@ check_pandas_support("sklearn_compat")
 
 ### Upgrading to scikit-learn 1.4
 
-#### `process_routing` function
+#### `process_routing` and `_raise_for_params` functions
 
-The signature of the `process_routing` function changed in scikit-learn 1.4. You don't
-need to change the import but only the call to the function. Calling the function with
-the new signature will be compatible with the previous signature as well. So a code
-looking like this:
+The signature of the `process_routing` function changed in scikit-learn 1.4. You can
+import the function from `sklearn_compat.utils.metadata_routing`. The pattern will
+change from:
 
 ``` py
+from sklearn.utils.metadata_routing import process_routing
+
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", fit_params, sample_weight=sample_weight)
@@ -528,10 +529,21 @@ class MetaEstimator(BaseEstimator):
 becomes:
 
 ``` py
+from sklearn_compat.utils.metadata_routing import process_routing
+
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", sample_weight=sample_weight, **fit_params)
         return self
+```
+
+The `_raise_for_params` function was also introduced in scikit-learn 1.4. You can import
+it from `sklearn_compat.utils.metadata_routing`.
+
+``` py
+from sklearn_compat.utils.metadata_routing import _raise_for_params
+
+_raise_for_params(params, self, "fit")
 ```
 
 #### Upgrading to scikit-learn 1.2

--- a/README.md
+++ b/README.md
@@ -513,13 +513,12 @@ check_pandas_support("sklearn_compat")
 
 #### `process_routing` and `_raise_for_params` functions
 
-The signature of the `process_routing` function changed in scikit-learn 1.4. You can
-import the function from `sklearn_compat.utils.metadata_routing`. The pattern will
-change from:
+The signature of the `process_routing` function changed in scikit-learn 1.4. You don't
+need to change the import but only the call to the function. Calling the function with
+the new signature will be compatible with the previous signature as well. So a code
+looking like this:
 
 ``` py
-from sklearn.utils.metadata_routing import process_routing
-
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", fit_params, sample_weight=sample_weight)
@@ -529,8 +528,6 @@ class MetaEstimator(BaseEstimator):
 becomes:
 
 ``` py
-from sklearn_compat.utils.metadata_routing import process_routing
-
 class MetaEstimator(BaseEstimator):
     def fit(self, X, y, sample_weight=None, **fit_params):
         params = process_routing(self, "fit", sample_weight=sample_weight, **fit_params)

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -208,11 +208,22 @@ if sklearn_version < parse_version("1.4"):
 
     if sklearn_version < parse_version("1.3"):
 
+        def process_routing(_obj, _method, /, **kwargs):
+            raise NotImplementedError(
+                "Metadata routing is not implemented in scikit-learn < 1.3"
+            )
+
         def _raise_for_params(params, owner, method):
             raise NotImplementedError(
                 "Metadata routing is not implemented in scikit-learn < 1.3"
             )
     else:
+
+        def process_routing(_obj, _method, /, **kwargs):
+            """Validate and route input parameters."""
+            from sklearn.utils._metadata_requests import process_routing
+
+            return process_routing(_obj, _method, other_params=None, **kwargs)
 
         def _raise_for_params(params, owner, method):
             """Raise an error if metadata routing is not enabled and params are passed."""
@@ -241,7 +252,10 @@ if sklearn_version < parse_version("1.4"):
         return isinstance(X, pd.DataFrame)
 
 else:
-    from sklearn.utils.metadata_routing import _raise_for_params  # noqa: F401
+    from sklearn.utils.metadata_routing import (
+        _raise_for_params,  # noqa: F401
+        process_routing,  # noqa: F401
+    )
     from sklearn.utils.validation import (
         _is_fitted,  # noqa: F401
         _is_pandas_df,  # noqa: F401

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -207,19 +207,12 @@ if sklearn_version < parse_version("1.4"):
         return len(fitted_attrs) > 0
 
     if sklearn_version < parse_version("1.3"):
-        # only define those functions to not raise an error.
-        def process_routing(_obj, _method, /, **kwargs):
-            pass
 
         def _raise_for_params(params, owner, method):
-            pass
+            raise NotImplementedError(
+                "Metadata routing is not implemented in scikit-learn < 1.3"
+            )
     else:
-
-        def process_routing(_obj, _method, /, **kwargs):
-            """Validate and route input parameters."""
-            from sklearn.utils._metadata_requests import process_routing
-
-            return process_routing(_obj, _method, other_params=None, **kwargs)
 
         def _raise_for_params(params, owner, method):
             """Raise an error if metadata routing is not enabled and params are passed."""
@@ -248,10 +241,7 @@ if sklearn_version < parse_version("1.4"):
         return isinstance(X, pd.DataFrame)
 
 else:
-    from sklearn.utils.metadata_routing import (
-        _raise_for_params,  # noqa: F401
-        process_routing,  # noqa: F401
-    )
+    from sklearn.utils.metadata_routing import _raise_for_params  # noqa: F401
     from sklearn.utils.validation import (
         _is_fitted,  # noqa: F401
         _is_pandas_df,  # noqa: F401

--- a/src/sklearn_compat/utils/metadata_routing.py
+++ b/src/sklearn_compat/utils/metadata_routing.py
@@ -1,0 +1,4 @@
+from sklearn_compat._sklearn_compat import (
+    _raise_for_params,  # noqa: F401
+    process_routing,  # noqa: F401
+)

--- a/src/sklearn_compat/utils/metadata_routing.py
+++ b/src/sklearn_compat/utils/metadata_routing.py
@@ -1,4 +1,1 @@
-from sklearn_compat._sklearn_compat import (
-    _raise_for_params,  # noqa: F401
-    process_routing,  # noqa: F401
-)
+from sklearn_compat._sklearn_compat import _raise_for_params  # noqa: F401

--- a/src/sklearn_compat/utils/metadata_routing.py
+++ b/src/sklearn_compat/utils/metadata_routing.py
@@ -1,1 +1,4 @@
-from sklearn_compat._sklearn_compat import _raise_for_params  # noqa: F401
+from sklearn_compat._sklearn_compat import (
+    _raise_for_params,  # noqa: F401
+    process_routing,  # noqa: F401
+)

--- a/src/sklearn_compat/utils/validation.py
+++ b/src/sklearn_compat/utils/validation.py
@@ -2,6 +2,7 @@ from sklearn_compat._sklearn_compat import (
     _check_feature_names,  # noqa: F401
     _check_n_features,  # noqa: F401
     _is_fitted,  # noqa: F401
+    _is_pandas_df,  # noqa: F401
     _to_object_array,  # noqa: F401
     check_array,  # noqa: F401
     validate_data,  # noqa: F401

--- a/tests/utils/test_metadata_routing.py
+++ b/tests/utils/test_metadata_routing.py
@@ -4,7 +4,7 @@ from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, clone
 
 from sklearn_compat._sklearn_compat import parse_version, sklearn_version
-from sklearn_compat.utils.metadata_routing import _raise_for_params, process_routing
+from sklearn_compat.utils.metadata_routing import _raise_for_params
 
 
 @pytest.mark.skipif(
@@ -12,7 +12,14 @@ from sklearn_compat.utils.metadata_routing import _raise_for_params, process_rou
     reason="Metadata routing was introduced in scikit-learn 1.3",
 )
 def test_process_routing():
-    from sklearn.utils.metadata_routing import MetadataRouter, MethodMapping
+    """This test is used to check that what we mentioned in the documentation is
+    correct.
+    """
+    from sklearn.utils.metadata_routing import (
+        MetadataRouter,
+        MethodMapping,
+        process_routing,
+    )
 
     class ExampleClassifier(ClassifierMixin, BaseEstimator):
         def fit(self, X, y, sample_weight=None):
@@ -59,3 +66,12 @@ def test_raise_for_params():
 
     with pytest.raises(ValueError, match="Passing extra keyword arguments"):
         _raise_for_params(params, est, "fit")
+
+
+@pytest.mark.skipif(
+    sklearn_version >= parse_version("1.3"),
+    reason="Metadata routing is implemented",
+)
+def test__raise_for_params_not_implemented():
+    with pytest.raises(NotImplementedError):
+        _raise_for_params(None, None, "fit")

--- a/tests/utils/test_metadata_routing.py
+++ b/tests/utils/test_metadata_routing.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+from sklearn import config_context
+from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, clone
+
+from sklearn_compat._sklearn_compat import parse_version, sklearn_version
+from sklearn_compat.utils.metadata_routing import _raise_for_params, process_routing
+
+
+@pytest.mark.skipif(
+    sklearn_version < parse_version("1.3"),
+    reason="Metadata routing was introduced in scikit-learn 1.3",
+)
+def test_process_routing():
+    from sklearn.utils.metadata_routing import MetadataRouter, MethodMapping
+
+    class ExampleClassifier(ClassifierMixin, BaseEstimator):
+        def fit(self, X, y, sample_weight=None):
+            self.sample_weight_ = sample_weight
+            # all classifiers need to expose a classes_ attribute once they're fit.
+            self.classes_ = np.array([0, 1])
+            return self
+
+    class MetaClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
+        def __init__(self, estimator):
+            self.estimator = estimator
+
+        def fit(self, X, y, sample_weight=None):
+            routed_params = process_routing(self, "fit", sample_weight=sample_weight)
+            self.estimator_ = clone(self.estimator).fit(
+                X, y, **routed_params.estimator.fit
+            )
+            return self
+
+        def get_metadata_routing(self):
+            router = MetadataRouter(owner=self.__class__.__name__).add(
+                estimator=self.estimator,
+                method_mapping=MethodMapping().add(caller="fit", callee="fit"),
+            )
+            return router
+
+    with config_context(enable_metadata_routing=True):
+        est = MetaClassifier(ExampleClassifier().set_fit_request(sample_weight=True))
+        sample_weight = [1, 2, 3]
+        est.fit(None, None, sample_weight=sample_weight)
+        assert est.estimator_.sample_weight_ == sample_weight
+
+
+@pytest.mark.skipif(
+    sklearn_version < parse_version("1.3"),
+    reason="Metadata routing was introduced in scikit-learn 1.3",
+)
+def test_raise_for_params():
+    class DummyEstimator(BaseEstimator):
+        pass
+
+    est = DummyEstimator()
+    params = {"invalid_param": 42}
+
+    with pytest.raises(ValueError, match="Passing extra keyword arguments"):
+        _raise_for_params(params, est, "fit")

--- a/tests/utils/test_metadata_routing.py
+++ b/tests/utils/test_metadata_routing.py
@@ -4,7 +4,7 @@ from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, clone
 
 from sklearn_compat._sklearn_compat import parse_version, sklearn_version
-from sklearn_compat.utils.metadata_routing import _raise_for_params
+from sklearn_compat.utils.metadata_routing import _raise_for_params, process_routing
 
 
 @pytest.mark.skipif(
@@ -12,14 +12,7 @@ from sklearn_compat.utils.metadata_routing import _raise_for_params
     reason="Metadata routing was introduced in scikit-learn 1.3",
 )
 def test_process_routing():
-    """This test is used to check that what we mentioned in the documentation is
-    correct.
-    """
-    from sklearn.utils.metadata_routing import (
-        MetadataRouter,
-        MethodMapping,
-        process_routing,
-    )
+    from sklearn.utils.metadata_routing import MetadataRouter, MethodMapping
 
     class ExampleClassifier(ClassifierMixin, BaseEstimator):
         def fit(self, X, y, sample_weight=None):
@@ -75,3 +68,5 @@ def test_raise_for_params():
 def test__raise_for_params_not_implemented():
     with pytest.raises(NotImplementedError):
         _raise_for_params(None, None, "fit")
+    with pytest.raises(NotImplementedError):
+        process_routing(None, "fit")


### PR DESCRIPTION
closes #28 

Add the missing functions needed for `imbalanced-learn`. The `process_routing` and `_raise_for_params` are no-op for sklearn < 1.3 since the infrastructure of metadata routing was not merged. We only allow to import for not erroring but most probably the library should handle it specifically for those version.