### PR TITLE
ENH backport the is_clusterer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ where `_sklearn_compat` is the vendored version of `sklearn-compat` in your proj
 
 ### Upgrading to scikit-learn 1.6
 
+#### `is_clusterer` function
+
+The function `is_clusterer` has been added in `scikit-learn` 1.6. So we backport it
+such that you can have access to it in scikit-learn 1.2+. The pattern is the following:
+
+``` py
+from sklearn.cluster import KMeans
+from sklearn_compat.base import is_clusterer
+
+is_clusterer(KMeans())
+```
+
 #### `validate_data` function
 
 Your previous code could have looked like this:

--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -369,6 +369,11 @@ else:
 
 
 if sklearn_version < parse_version("1.6"):
+    # base
+    def is_clusterer(estimator):
+        """Return True if the given estimator is (probably) a clusterer."""
+        return get_tags(estimator).estimator_type == "clusterer"
+
     # test_common
     from sklearn.utils.estimator_checks import _construct_instance
 
@@ -832,6 +837,9 @@ if sklearn_version < parse_version("1.6"):
         return parametrize_with_checks(estimators)
 
 else:
+    # base
+    from sklearn.base import is_clusterer  # noqa: F401
+
     # test_common
     # tags infrastructure
     from sklearn.utils import (

--- a/src/sklearn_compat/base.py
+++ b/src/sklearn_compat/base.py
@@ -1,3 +1,4 @@
 from sklearn_compat._sklearn_compat import (
     _fit_context,  # noqa: F401
+    is_clusterer,  # noqa: F401
 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,9 @@
+from sklearn.cluster import KMeans
+from sklearn.linear_model import LinearRegression
+
+from sklearn_compat.base import is_clusterer
+
+
+def test_is_clusterer():
+    assert is_clusterer(KMeans())
+    assert not is_clusterer(LinearRegression())


### PR DESCRIPTION
While playing with `skore` I see that having the completness `is_***` functions for all scikit-learn supported versions is handy.