### PR TITLE
Remove multi_label from RegressorTags

### DIFF
--- a/src/sklearn_compat/_sklearn_compat.py
+++ b/src/sklearn_compat/_sklearn_compat.py
@@ -109,7 +109,6 @@ def _to_new_tags(old_tags, estimator=None):
     if estimator_type == "regressor":
         regressor_tags = RegressorTags(
             poor_score=old_tags["poor_score"],
-            multi_label=old_tags["multilabel"],
         )
     else:
         regressor_tags = None
@@ -715,13 +714,9 @@ if sklearn_version < parse_version("1.6"):
             n_informative=1, bias=5.0, noise=20, random_state=42)``. The
             dataset and values are based on current estimators in scikit-learn
             and might be replaced by something more systematic.
-
-        multi_label : bool, default=False
-            Whether the regressor supports multilabel output.
         """
 
         poor_score: bool = False
-        multi_label: bool = False
 
     @dataclass(**_dataclass_args())
     class Tags:


### PR DESCRIPTION
Those were removed from the RegressorTags in https://github.com/scikit-learn/scikit-learn/pull/30373 .